### PR TITLE
Linux support: use devkitPPC's `powerpc-eabi-as` and `powerpc-eabi-objcopy`

### DIFF
--- a/gecko.go
+++ b/gecko.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -347,21 +348,50 @@ func compile(file string) []byte {
 	}
 	defer os.Remove("asm-to-compile.asm")
 
-	cmd := exec.Command("powerpc-gekko-as.exe", "-a32", "-mbig", "-mregnames", "-mgekko", "asm-to-compile.asm")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("Failed to compile file: %s\n", file)
-		fmt.Printf("%s", output)
-		os.Exit(1)
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command("powerpc-gekko-as.exe", "-a32", "-mbig", "-mregnames", "-mgekko", "asm-to-compile.asm")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Failed to compile file: %s\n", file)
+			fmt.Printf("%s", output)
+			os.Exit(1)
+		}
+		contents, err := ioutil.ReadFile("a.out")
+		if err != nil {
+			log.Fatalf("Failed to read compiled file %s\n%s\n", file, err.Error())
+		}
+
+		// I don't understand how this works (?)
+		codeEndIndex := bytes.Index(contents, []byte{0x00, 0x2E, 0x73, 0x79, 0x6D, 0x74, 0x61, 0x62})
+		return contents[52:codeEndIndex]
 	}
 
-	contents, err := ioutil.ReadFile("a.out")
-	if err != nil {
-		log.Fatalf("Failed to read compiled file %s\n%s\n", file, err.Error())
+	// Just pray that powerpc-eabi-{as,objcopy} are in the user's $PATH, lol
+	if runtime.GOOS == "linux" {
+		cmd := exec.Command("powerpc-eabi-as", "-a32", "-mbig", "-mregnames", "asm-to-compile.asm")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Failed to compile file: %s\n", file)
+			fmt.Printf("%s", output)
+			os.Exit(1)
+		}
+		cmd = exec.Command("powerpc-eabi-objcopy", "-O", "binary", "a.out", "a.out")
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Failed to pull out .text section: %s\n", file)
+			fmt.Printf("%s", output)
+			os.Exit(1)
+		}
+		contents, err := ioutil.ReadFile("a.out")
+		if err != nil {
+			log.Fatalf("Failed to read compiled file %s\n%s\n", file, err.Error())
+		}
+		return contents
 	}
-	codeEndIndex := bytes.Index(contents, []byte{0x00, 0x2E, 0x73, 0x79, 0x6D, 0x74, 0x61, 0x62})
 
-	return contents[52:codeEndIndex]
+	log.Fatalf("Platform unsupported?\n");
+	os.Exit(1);
+	return nil
 }
 
 func writeOutput(outputFile string) {

--- a/gecko.go
+++ b/gecko.go
@@ -46,6 +46,7 @@ const (
 	Branch           = "branch"
 	BranchAndLink    = "branchAndLink"
 	InjectFolder     = "injectFolder"
+	ReplaceBinary    = "replaceBinary"
 )
 
 var output []string
@@ -130,6 +131,10 @@ func generateCodeLines(desc CodeDescription) []string {
 			result = append(result, lines...)
 		case ReplaceCodeBlock:
 			lines := generateReplaceCodeBlockLines(geckoCode.Address, geckoCode.SourceFile)
+			lines[0] = addLineAnnotation(lines[0], geckoCode.Annotation)
+			result = append(result, lines...)
+		case ReplaceBinary:
+			lines := generateReplaceBinaryLines(geckoCode.Address, geckoCode.SourceFile)
 			lines[0] = addLineAnnotation(lines[0], geckoCode.Annotation)
 			result = append(result, lines...)
 		case Branch:
@@ -327,6 +332,36 @@ func generateReplaceCodeBlockLines(address, file string) []string {
 
 	return lines
 }
+
+func generateReplaceBinaryLines(address, file string) []string {
+	// TODO: Add error if address or value is incorrect length/format
+	lines := []string{}
+
+	contents, err := ioutil.ReadFile(file)
+	if err != nil {
+		log.Fatalf("Failed to read binary file %s\n%s\n", file, err.Error())
+	}
+
+	instructions := contents
+
+
+	// Fixes code to have an even number of words
+	if len(instructions)%8 != 0 {
+		instructions = append(instructions, 0x60, 0x00, 0x00, 0x00)
+	}
+
+	lines = append(lines, fmt.Sprintf("06%s %08X", strings.ToUpper(address[2:]), len(instructions)))
+
+	for i := 0; i < len(instructions); i += 8 {
+		left := strings.ToUpper(hex.EncodeToString(instructions[i : i+4]))
+		right := strings.ToUpper(hex.EncodeToString(instructions[i+4 : i+8]))
+		lines = append(lines, fmt.Sprintf("%s %s", left, right))
+	}
+
+	return lines
+}
+
+
 
 func compile(file string) []byte {
 	defer os.Remove("a.out")


### PR DESCRIPTION
* Assumes user has `powerpc-eabi-as` and `powerpc-eabi-objcopy`
* Normal code didn't seem to pull out the `.text` section properly for me (included the whole data section - not sure if this is a platform-specific thing?), so it's just using `objcopy` to get the contents
* Also added an option for including a binary file (figured this might be useful)

I don't really use Golang so often - dunno if `runtime.GOOS` is sufficient for distinguishing between platforms. Perhaps you might have a better solution. 