### PR TITLE
return error to shell on failure

### DIFF
--- a/gecko.go
+++ b/gecko.go
@@ -86,6 +86,8 @@ func main() {
 		if r == nil {
 			// Here we completed successfully, in that case, show time output
 			timeTrack(startTime)
+		} else {
+			os.Exit(1)
 		}
 	}(time.Now())
 


### PR DESCRIPTION
We're using gecko to build [TrainingMode-More](https://github.com/AlexanderHarrison/TrainingMode-More/blob/master/build_windows.bat) in a shell script. We need to cleanup and exit on any failure, but gecko always returns success, even on failure. This two line fix should remedy that.