### PR TITLE
enable OUTPUT key in FileDescription.File

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -45,9 +45,6 @@ type compileJob struct {
 }
 
 func execBatchCompile(jobs []compileJob) {
-	const asCmdLinux string = "powerpc-eabi-as"
-	const objcopyCmdLinux string = "powerpc-eabi-objcopy"
-
 	deleteFile := func(fp string) {
 		defer compileWaitGroup.Done()
 		os.Remove(fp)
@@ -181,9 +178,6 @@ func compile(file, addressExp string) ([]byte, string) {
 	buildTempAsmFile(file, addressExp, compileFilePath, "")
 
 	fileDir := filepath.Dir(file)
-
-	const asCmdLinux string = "powerpc-eabi-as"
-	const objcopyCmdLinux string = "powerpc-eabi-objcopy"
 
 	// Set base args
 	args := []string{"-a32", "-mbig", "-mregnames", "-mgekko"}

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,4 @@
+package main
+
+const asCmdLinux string = "powerpc-eabi-as"
+const objcopyCmdLinux string = "powerpc-eabi-objcopy"


### PR DESCRIPTION
problem: i would like to build my codes directly to my dolphin's GALE01.ini file while not including machine specific info in the codes.json file path.

solution: provide $OUTPUT key for file path. users can run
```
export OUTPUT=/path/to/Dolphin/GameSettings
gecko build
```
and codes with file path in format
```
"file": "$OUTPUT/GALE01.ini",
```
will build to "/path/to/Dolphin/GameSettings/GALE01.ini"